### PR TITLE
Fix: ch02 typo

### DIFF
--- a/ch02/chitchat/route_auth.go
+++ b/ch02/chitchat/route_auth.go
@@ -2,7 +2,7 @@ package main
 
 import (
 //	"github.com/sausheong/gwp/Chapter_2_Go_ChitChat/chitchat/data"
-	"github.com/mushahiroyuki/gowebprog/ch02/chitchut/data"
+	"github.com/mushahiroyuki/gowebprog/ch02/chitchat/data"
 	"net/http"
 )
 

--- a/ch02/chitchat/route_main.go
+++ b/ch02/chitchat/route_main.go
@@ -2,7 +2,7 @@ package main
 
 import (
  // 	"github.com/sausheong/gwp/Chapter_2_Go_ChitChat/chitchat/data"
-	"github.com/mushahiroyuki/gowebprog/ch02/chitchut/data"
+	"github.com/mushahiroyuki/gowebprog/ch02/chitchat/data"
 	"net/http"
 )
 

--- a/ch02/chitchat/route_thread.go
+++ b/ch02/chitchat/route_thread.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 	// 	"github.com/sausheong/gwp/Chapter_2_Go_ChitChat/chitchat/data"
-	"github.com/mushahiroyuki/gowebprog/ch02/chitchut/data"
+	"github.com/mushahiroyuki/gowebprog/ch02/chitchat/data"
 	"net/http"
 )
 

--- a/ch02/chitchat/utils.go
+++ b/ch02/chitchat/utils.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 	// 	"github.com/sausheong/gwp/Chapter_2_Go_ChitChat/chitchat/data"
-	"github.com/mushahiroyuki/gowebprog/ch02/chitchut/data"
+	"github.com/mushahiroyuki/gowebprog/ch02/chitchat/data"
 	"html/template"
 	"log"
 	"net/http"


### PR DESCRIPTION
ch02/chitchat/README.md 手順4 `go build` 以下エラーに対処
ch02/chitchut は存在しないしないため `s/chitchut/chitchat/g` とした

```
$ go build
route_auth.go:5:2: cannot find package "github.com/mushahiroyuki/gowebprog/ch02/chitchut/data" in any of:
        ${GOROOT}/src/github.com/mushahiroyuki/gowebprog/ch02/chitchut/data (from $GOROOT)
        ${GOPATH}/src/github.com/mushahiroyuki/gowebprog/ch02/chitchut/data (from $GOPATH)
```